### PR TITLE
Not setting compute_device_type to None when setting to CUDA fails

### DIFF
--- a/eyemodel/blender_script.py.template
+++ b/eyemodel/blender_script.py.template
@@ -248,7 +248,6 @@ if bpy.context.user_preferences.system.compute_device_type != 'CUDA':
         bpy.context.user_preferences.system.compute_device_type = 'CUDA'
     except:
         print("Warning: Setting compute device to CUDA failed, using CPU rendering (will be much slower)")
-        bpy.context.user_preferences.system.compute_device_type = 'None'
 
 if output_params_path:
     def mlabVec(vec):


### PR DESCRIPTION
For some reason it didn't work with the removed line.
Now working with CPU without OSL.
