### PR TITLE
Making .m compatible with Octave

### DIFF
--- a/eyemodel/blender_script.py.template
+++ b/eyemodel/blender_script.py.template
@@ -371,7 +371,7 @@ if output_params_path:
             "    end",
             "end",
             "pupil_points = camera_project(camera, pupil_refracted_vertices);",
-            "pupil_points = pupil_points(:, convhull(pupil_points'));",
+            "pupil_points = pupil_points(:, convhull(pupil_points(1,:)', pupil_points(2,:)'));",
             "plot(camera.resolution(1)/2 + pupil_points(1,:), camera.resolution(2)/2 - pupil_points(2,:), '-m', 'LineWidth', 1.5);",
         ]
         for i,light in enumerate(input_lights):


### PR DESCRIPTION
I don't have a Matlab license, so I only tested on Octave.

On Octave I got this error:
error: surface: z and c must have same size
error: called from:
error:   /usr/share/octave/3.2.4/m/plot/surface.m at line 85, column 7
error:   /usr/share/octave/3.2.4/m/plot/surface.m at line 51, column 5
error:   /usr/share/octave/3.2.4/m/plot/surf.m at line 47, column 5
error:   $BOHME/eye_draw.m at line 55, column 6
error:   eye1.m at line 42, column 1
